### PR TITLE
Add compile dependency to provider

### DIFF
--- a/src/rebar3_auto.erl
+++ b/src/rebar3_auto.erl
@@ -23,7 +23,7 @@
 -export([auto/0, flush/0]).
 
 -define(PROVIDER, auto).
--define(DEPS, [compile, app_discovery]).
+-define(DEPS, [compile]).
 
 %% ===================================================================
 %% Public API

--- a/src/rebar3_auto.erl
+++ b/src/rebar3_auto.erl
@@ -23,7 +23,7 @@
 -export([auto/0, flush/0]).
 
 -define(PROVIDER, auto).
--define(DEPS, [app_discovery]).
+-define(DEPS, [compile, app_discovery]).
 
 %% ===================================================================
 %% Public API


### PR DESCRIPTION
This is required for app paths to be setup properly, same as shell
provider does
