### PR TITLE
ReadMe update changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Add the plugin to your rebar config, since it is a developer tool and not necess
 
 
 Then run
+```
     $ rebar3 compile
-
+```
 
 Then just call your plugin directly in an existing application:
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,22 @@ rebar_auto_plugin
 
 A rebar3 plugin for auto running compile on source file change reloading modules in the shell.
 
-Build
+Prerequisite
 -----
+On Linux you need to install inotify-tools.
 
-    $ rebar3 compile
 
 Use
 ---
 
-Add the plugin to your rebar config, since it is a developer tool and not necessary for building any project you work on I put it in `~/config/.rebar3/rebar.config`:
+Add the plugin to your rebar config, since it is a developer tool and not necessary for building any project you work on I put it in `~/.config/rebar3/rebar.config`:
 
     {plugins, [rebar3_auto]}.
+
+
+Then run
+    $ rebar3 compile
+
 
 Then just call your plugin directly in an existing application:
 


### PR DESCRIPTION
I had a number of problems getting the plugin to work. 

Firstly the order as described by the readme is rebar3 compile then add the line to the rebar.config file. This was incorrect order. 

Additionally you have to dig through the rebar.conf of this repo then go and find the rquired library to be installed for linux. 

The directory for the rebar3 config was in a different place https://github.com/tsloughter/rebar3_auto/issues/8
