### PR TITLE
move rebar config options to {auto, [...]}, add extra_dirs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,18 @@ Regex matches are supported, "$" is suffixed automatically, thanks xuchaoqian.
 re:run(<<"file_name.erl_ab">>, <<ExtMatch/binary, "$">>)
 ```
 
-```
+
 To extend the list add an option to your rebar.config like so:
+```
+{auto, [
+	{extra_extensions, [".alp", ".hterl", ".erl(.*?)"]}
+]}.
+```
 
-{extra_extensions, [".alp", ".hterl", ".erl(.*?)"]}.
-
+Extra directories.
+To extend the list of directories to be watched add an option to your rebar.config like so:
+```
+{auto, [
+	{extra_dirs, ["priv/dtl"]}
+]}.
 ```

--- a/src/rebar3_auto.app.src
+++ b/src/rebar3_auto.app.src
@@ -1,6 +1,6 @@
 {application,rebar3_auto,
              [{description,"Rebar3 plugin for auto compiling on changes"},
-              {vsn,"0.5.1"},
+              {vsn,"0.6.0"},
               {registered,[]},
               {applications,[kernel,stdlib,fs]},
               {env,[]},


### PR DESCRIPTION
This commit does two things.
1. moves rebar config file option `extra_extensions` into `{auto, [{extra_extensions, ...}]}`. The old way is kept too for backward compatibility.
2. adds ability to watch extra directories for changes and accordingly `extra_dirs` option for configuration.

so config in the rebar.,config would look like this
```
{auto, [
	{extra_extensions, [".dtl"]},
	{extra_dirs, ["priv/dtl"]}
]}.
```
These changes allow watching and recompiling things such as django dtl templates.


I think it also fixes a subtle bug - `fs:start_link/fs:subscribe` should have unique handles for each app but plugin used to create them with the same handle varying only on ``src/c_src`.

I added some docs and bumped up the version.


